### PR TITLE
Implemented Sane Registry + Started Musicians

### DIFF
--- a/lib/progressions/rooms.ex
+++ b/lib/progressions/rooms.ex
@@ -23,7 +23,7 @@ defmodule Progressions.Rooms do
   """
   @spec room_exists?(String.t()) :: boolean()
   def room_exists?(room_id) do
-    Pids.get_room(room_id) != nil
+    Pids.fetch({:room, room_id}) != nil
   end
 
   @doc """

--- a/lib/progressions/rooms/room.ex
+++ b/lib/progressions/rooms/room.ex
@@ -4,10 +4,14 @@ defmodule Progressions.Rooms.Room do
   """
   use Supervisor
 
-  alias Progressions.Rooms.Room.{
-    Server,
-    TimestepClock
+  alias Progressions.{
+    Pids,
+    Rooms.Room.Server,
+    Rooms.Room.TimestepClock,
+    Rooms.Room.Musicians
   }
+
+  alias Progressions.Pids
 
   def start_link(room_id) do
     Supervisor.start_link(__MODULE__, room_id)
@@ -17,8 +21,11 @@ defmodule Progressions.Rooms.Room do
   def init(room_id) do
     children = [
       {Server, [room_id]},
-      {TimestepClock, [room_id]}
+      {TimestepClock, [room_id]},
+      {Musicians, [room_id]}
     ]
+
+    Pids.register({:room, room_id}, self())
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/lib/progressions/rooms/room/musicians.ex
+++ b/lib/progressions/rooms/room/musicians.ex
@@ -1,0 +1,43 @@
+defmodule Progressions.Rooms.Room.Musicians do
+  @moduledoc """
+  Dynamic supervisor for musicians in a room
+  """
+  use DynamicSupervisor
+
+  alias Progressions.{
+    Rooms.Room.Musicians.Musician,
+    Pids
+  }
+
+  @type id() :: String.t()
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg)
+  end
+
+  @impl true
+  def init([room_id]) do
+    Pids.register({:musicians, room_id}, self())
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  @doc """
+  Check if a musician process exists for the given id
+  """
+  @spec musician_exists?(id(), id()) :: boolean()
+  def musician_exists?(musician_id, room_id) do
+    Pids.fetch({:musician, {musician_id, room_id}}) != nil
+  end
+
+  @doc """
+  Start a musician under supervision.
+  """
+  @spec add_musician(pid(), id(), id()) :: {atom(), pid() | String.t()}
+  def add_musician(pid, musician_id, room_id) do
+    if !musician_exists?(musician_id, room_id) do
+      DynamicSupervisor.start_child(pid, {Musician, [musician_id, room_id]})
+    else
+      {:error, "musician already exists for musician_id #{musician_id} in room #{room_id}"}
+    end
+  end
+end

--- a/lib/progressions/rooms/room/musicians/musician.ex
+++ b/lib/progressions/rooms/room/musicians/musician.ex
@@ -1,0 +1,25 @@
+defmodule Progressions.Rooms.Room.Musicians.Musician do
+  @moduledoc """
+  Maintains state and exposes API for interacting with a single musician
+  """
+  use GenServer
+
+  alias Progressions.{Pids}
+
+  @type musician_state() :: %{
+          musician_id: String.t(),
+          # TODO use struct for loop
+          active_loop: %{},
+          potential_loop: %{}
+        }
+
+  def start_link(init_arg) do
+    GenServer.start_link(__MODULE__, init_arg)
+  end
+
+  @impl true
+  def init([musician_id, room_id]) do
+    Pids.register({:musician, {musician_id, room_id}}, self())
+    {:ok, %{musician_id: musician_id, active_loop: %{}, potential_loop: %{}}}
+  end
+end

--- a/lib/progressions/rooms/room/server.ex
+++ b/lib/progressions/rooms/room/server.ex
@@ -17,7 +17,7 @@ defmodule Progressions.Rooms.Room.Server do
 
   @impl true
   def init([room_id]) do
-    Pids.register_room(room_id, self())
+    Pids.register({:server, room_id}, self())
     {:ok, %{room_id: room_id, timesteps: []}}
   end
 
@@ -30,6 +30,7 @@ defmodule Progressions.Rooms.Room.Server do
   end
 
   @spec handle_cast(:broadcast_timesteps, room_state()) :: {:noreply, room_state()}
+  @impl true
   def handle_cast(:broadcast_timesteps, %{room_id: room_id, timesteps: timesteps}) do
     topic = "room:" <> room_id
 

--- a/test/progressions/pids_test.exs
+++ b/test/progressions/pids_test.exs
@@ -1,13 +1,16 @@
 defmodule Progressions.PidsTest do
   use ExUnit.Case, async: true
 
-  alias Progressions.{Pids}
+  alias Progressions.{
+    Pids,
+    Rooms
+  }
 
   test "registers and returns supported pids" do
     room_ids = ["41231", "52323", "6123412"]
 
-    reg_results = Enum.map(room_ids, &Pids.register_room(&1, fn _ -> nil end))
-    get_results = Enum.map(room_ids, &Pids.get_room(&1))
+    reg_results = Enum.map(room_ids, &Pids.register({:room, &1}, fn _ -> nil end))
+    get_results = Enum.map(room_ids, &Pids.fetch({:room, &1}))
 
     assert length(room_ids) == length(reg_results)
     assert length(room_ids) == length(get_results)
@@ -22,6 +25,8 @@ defmodule Progressions.PidsTest do
   end
 
   test "returns nil for pid not found" do
-    assert nil == Pids.get_room("928u902817482")
+    assert nil == Pids.fetch({:room, "928u902817482"})
   end
+
+  # TODO more tests for different types
 end

--- a/test/progressions/rooms/room/musicians_test.exs
+++ b/test/progressions/rooms/room/musicians_test.exs
@@ -1,0 +1,16 @@
+defmodule Progressions.Room.MusiciansTest do
+  use ExUnit.Case, async: true
+
+  alias Progressions.Rooms.Room.Musicians
+
+  test "add musicians to room and lookup them up" do
+    room_id = "room_id"
+
+    {:ok, musician_pid} = Musicians.start_link([room_id])
+    {:ok, m1} = Musicians.add_musician(musician_pid, "1", room_id)
+    {:ok, m2} = Musicians.add_musician(musician_pid, "2", room_id)
+
+    assert Musicians.musician_exists?("1", room_id) == true
+    assert Musicians.musician_exists?("2", room_id) == true
+  end
+end

--- a/test/progressions/rooms/room/server_test.exs
+++ b/test/progressions/rooms/room/server_test.exs
@@ -1,0 +1,7 @@
+defmodule Progressions.Room.ServerTest do
+  use ExUnit.Case, async: true
+
+  test "broadcasts messages" do
+    nil
+  end
+end

--- a/test/progressions/rooms/room_test.exs
+++ b/test/progressions/rooms/room_test.exs
@@ -3,8 +3,9 @@ defmodule Progressions.RoomTest do
 
   alias Progressions.Rooms.{
     Room,
-    Room.TimestepClock,
-    Room.Server
+    Room.Musicians,
+    Room.Server,
+    Room.TimestepClock
   }
 
   test "sets up expected supervision tree for single room" do
@@ -13,6 +14,7 @@ defmodule Progressions.RoomTest do
     {:ok, sup} = Room.start_link(room_id)
 
     assert [
+             {Musicians, _, :supervisor, [Musicians]},
              {TimestepClock, _, :worker, [TimestepClock]},
              {Server, _, :worker, [Server]}
            ] = Supervisor.which_children(sup)


### PR DESCRIPTION
- Registry uses tuple keys {process_type, identifiers} to organize
  references to all children of a room supervision tree.
- Register all child processes in a room supervision tree.
- Allow neighbor processes to look each other up via registry
- Started implementation of musicians subtree